### PR TITLE
Очищает Local Storage если бэкенд вернул ошибку

### DIFF
--- a/src/services/auth/operations.ts
+++ b/src/services/auth/operations.ts
@@ -39,11 +39,11 @@ export const signin = (params: ISigninRequest): ThunkAction<void, unknown, null,
 };
 
 export const logout = (): ThunkAction<void, unknown, null, AnyAction> => (dispatch) => {
+  localStorage.clear();
   auth.logout(
     null,
     () => {
       dispatch(actions.logoutSuccess());
-      localStorage.clear();
     },
     ({ message, response }) => {
       const errorMessage = response ? response.data.reason : message;


### PR DESCRIPTION
Сейчас, если бэкенд вернул ошибку, в Local Storage не очищается и при следующей загрузке, приложение считает, что пользователь авторизован.